### PR TITLE
Handle err before stats

### DIFF
--- a/lib/webpackPlugin.js
+++ b/lib/webpackPlugin.js
@@ -114,17 +114,19 @@ class WebpackPlugin {
 	}
 
 	compileCallback(err, stats){
-		if(stats.hash === this._lastStatsHash){
-			return;
-		}
-		this._lastStatsHash = stats.hash;
-
+		
 		// error handling
 		if(err){
 			this.error(err);
 
 			return;
 		}
+
+		if(stats.hash === this._lastStatsHash){
+			return;
+		}
+		this._lastStatsHash = stats.hash;
+
 		const info = stats.toJson();
 		if(stats.hasErrors()){
 			for(let item of info.errors){


### PR DESCRIPTION
I was running into trouble where `stats` was undefined when there was an error indicating that a module could not be found.

The result was the webpack build errored out saying that cannot read property `hash` on undefined rather than push the error into the webpack error stream.

This just moves the error handling up so that's done first and returns if there is an error. 

All tests still passing.