### PR TITLE
Support vinyl-named and multiple files per chunkName

### DIFF
--- a/lib/webpackPlugin.js
+++ b/lib/webpackPlugin.js
@@ -86,7 +86,10 @@ class WebpackPlugin {
 				throw new Error('Unsupported additionalEntries data type. Make sure it is array or function');
 			}
 		}else{
-			this.config.entry[chunkName] = [file.path];
+		 	if(!Array.isArray(this.config.entry[chunkName])) {
+        			this.config.entry[chunkName] = []
+      			}
+      			this.config.entry[chunkName].push(file.path);
 		}
 	}
 
@@ -114,7 +117,7 @@ class WebpackPlugin {
 	}
 
 	compileCallback(err, stats){
-		
+
 		// error handling
 		if(err){
 			this.error(err);
@@ -181,7 +184,7 @@ class WebpackPlugin {
 		// seems that vinyl-fs doesn't set file.stem for us
 		let filename = path.basename(file.path);
 
-		return gutil.replaceExtension(filename, '');
+		return file.named || gutil.replaceExtension(filename, '');
 	}
 
 	prepareConfig(){


### PR DESCRIPTION
`webpack-stream` supports a `.named` property from `vinyl-named` as well as multiple files per chunk name. This adds feature parity.

https://github.com/shama/webpack-stream#multiple-entry-points